### PR TITLE
More command line options and Fixed song playing error (#16)

### DIFF
--- a/src/Sound.cpp
+++ b/src/Sound.cpp
@@ -149,6 +149,7 @@ void Sound::play_next() {
         playedFiles.clear();
     }
     
+
     do {
         accept_song = true;
         
@@ -166,7 +167,7 @@ void Sound::play_next() {
             for(it = filelist.begin(); it < filelist.end(); it++) {
                 int song_num = it - filelist.begin();
                 if(*it == this->getCurrentSong()) {
-                    if(song_num == filelist.size()) {
+                    if(song_num == filelist.size()-1) {
                         song_num = 0;
                     }
                     nextSong = filelist[song_num + 1];
@@ -178,15 +179,19 @@ void Sound::play_next() {
             }
         }
         
-        if(nextSong == this->getCurrentSong() && filelist.size() > 1) {
-            accept_song = false;
-        }
-        
+		if(playedFiles.size() > 1)
+		{
+			if(nextSong == this->getCurrentSong() && filelist.size() > 1) {
+				accept_song = false;
+			}
+		}
+
         for(it = playedFiles.begin(); it < playedFiles.end(); it++) {
             if(*it == nextSong) {
                 accept_song = false;
             }
         }
+
     } while(accept_song == false);
     
     filesystem::path track_dir(nextSong);

--- a/src/Windows/Pipe.cpp
+++ b/src/Windows/Pipe.cpp
@@ -17,7 +17,7 @@ Pipe::Pipe(const char* fifo_dir):
 
   const char* mutex_name = "/tmp/revengeMusic.pid";
 
-  //Initialize OVERLAPPED structure for asycn. pipes
+  //Initialize OVERLAPPED structure for async. pipes
   pipe_info = {0,0,0,0,NULL};
   pipe_info.hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,14 +48,31 @@ int main( int argc, char *argv[]) {
         }
     } else if(pipe.isOnlyInstance()) {
 
-        if(argv[1] == NULL) {
-            std::cerr << "Error track name invalid" << std::endl;
+        if(argc < 1) {
+            std::cerr << "Error, missing arguments." << std::endl;
             return -2;
         }
 
         std::string music_dir;
         std::string track_dir;
-        std::string track_name = argv[1];
+        std::string track_name;
+        std::string subdirectory;
+
+		//Check command line arguments
+        for(int i = 1; i < argc; ++i)
+        {
+          if(strcmp(argv[i],"-subdir") == 0)
+          {
+            ++i;
+            if(i < argc)
+            { 
+              subdirectory = argv[i]; 
+              subdirectory += "/";
+            }
+          }
+          else
+          { track_name = argv[i]; }
+        }
 
         //Get home directory of user
         #ifdef __unix
@@ -93,9 +110,11 @@ int main( int argc, char *argv[]) {
         #endif
 
         track_dir += music_dir;
+        track_dir += subdirectory;
         track_dir += track_name;
 
-        Sound song(music_dir.c_str());
+        Sound song(subdirectory == "" ? music_dir.c_str() : track_dir.c_str());
+
         song.init();
         std::cout << "Playing file: " << track_name << std::endl;
         song.play(track_dir.c_str());


### PR DESCRIPTION
- Added Async pipes for windows and minor fixes to the build
- Added support for more command line options and Fixed song playing error

Fixed a spelling mistake in a comment in Pipe.cpp
It now can check all command line arguments and added an argument named -subdir so that a user can specify the a specific folder within the music folder.
Fixed an error with getCurrentSong() failing in the play_next loop because of the playedFiles vector being cleared.
- Changed for loop for consistency
