### PR TITLE
Added Async pipes for windows and minor fixes to the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,20 +17,6 @@ IF(NOT WIN32)
 ENDIF(NOT WIN32)
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS}" )
 
-#Find FMOD
-find_package(FMOD)
-IF(FMOD_FOUND)
-  include_directories(${FMOD_INCLUDE_DIRS})
-ELSEIF(NOT WIN32)
-  include_directories(${PROJECT_BINARY_DIR}/fmod/api/lowlevel/inc)
-ENDIF(FMOD_FOUND)
-
-#Find Boost
-find_package(Boost 1.58 COMPONENTS filesystem REQUIRED)
-IF(Boost_FOUND)
-  include_directories(${Boost_INCLUDE_DIRS})
-ENDIF(Boost_FOUND)
-
 IF(WIN32)
 add_executable(
   revengeMusic
@@ -39,6 +25,7 @@ add_executable(
   src/Sound.cpp
   src/Logger.cpp
 )
+set(Boost_USE_STATIC_LIBS ON)
 set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT "revengeMusic")
 ELSEIF(UNIX)
 add_executable(
@@ -50,6 +37,16 @@ add_executable(
 )
 ENDIF(WIN32)
 
+#Find Boost
+find_package(Boost 1.58 COMPONENTS filesystem REQUIRED)
+IF(Boost_FOUND)
+  include_directories(${Boost_INCLUDE_DIRS})
+  target_link_libraries(revengeMusic ${Boost_LIBRARIES})
+ENDIF(Boost_FOUND)
+
+#Find FMOD
+find_package(FMOD)
 IF(FMOD_FOUND)
-  target_link_libraries(revengeMusic ${Boost_LIBRARIES} ${FMOD_LIBRARIES})
+  include_directories(${FMOD_INCLUDE_DIRS})
+  target_link_libraries(revengeMusic  ${FMOD_LIBRARIES})
 ENDIF(FMOD_FOUND)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ best case scenario is to mod rofi to play music files
 ./revengeMusic (--commands | <path>)
     commands:
         -h, --help      Shows this message
+        -subdir         Specify a specific folder within the Music directory
         kill            Exits revengeMusic
         play            Unpause song
         pause           Pause song


### PR DESCRIPTION
Added support for more command line options and Fixed song playing error

Fixed a spelling mistake in a comment in Pipe.cpp
It now can check all command line arguments and added an argument named -subdir so that a user can specify the a specific folder within the music folder.
Fixed an error with getCurrentSong() failing in the play_next loop because of the playedFiles vector being cleared.

Changed for loop for consistency

Fixed Windows Pipe

The error, after investigation, seemed to be because of a Pipe not being disconnected after there were errors.

Added support for more command line options and Fixed song playing error (#25)
- Added Async pipes for windows and minor fixes to the build
- Added support for more command line options and Fixed song playing error

Fixed a spelling mistake in a comment in Pipe.cpp
It now can check all command line arguments and added an argument named -subdir so that a user can specify the a specific folder within the music folder.
Fixed an error with getCurrentSong() failing in the play_next loop because of the playedFiles vector being cleared.
- Changed for loop for consistency

Added support for more command line options and Fixed song playing error (#16) (#26)
- Added Async pipes for windows and minor fixes to the build
- Added support for more command line options and Fixed song playing error

Fixed a spelling mistake in a comment in Pipe.cpp
It now can check all command line arguments and added an argument named -subdir so that a user can specify the a specific folder within the music folder.
Fixed an error with getCurrentSong() failing in the play_next loop because of the playedFiles vector being cleared.
- Changed for loop for consistency

Fix compile on Linux

Added -subdir command to readme.md
