### PR TITLE
Added slight delay to prevent sending message to same process

### DIFF
--- a/src/MessageQueue.cpp
+++ b/src/MessageQueue.cpp
@@ -109,6 +109,8 @@ bool MessageQueue::GetMessage(std::string& msg, message_queue::size_type recvd_s
 bool MessageQueue::SendMessage(const char* msg) {
     try {
         queue->send(msg, std::strlen(msg)+1, 0);
+        //Delay to prevent sending message to self
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
     catch(interprocess_exception &ex) {
         Logger::Error error(ErrorType::Recoverable, "Could not send message!");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -196,8 +196,6 @@ int main( int argc, char *argv[]) {
                 } else {
                     mq.SendMessage("Invalid");
                 }
-                //Delay to prevent sending message to self
-                std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }
         }
 


### PR DESCRIPTION
Partially Fixes #43
This solution still allows for a process to read its own message from the queue, so a better solution is necessary. 
Possibly create two separate queues:
- one for sending from the secondary processes to the primary process
- one for sending from the primary process to the secondary processes