### PR TITLE
Build scripts for Windows that account for both build types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ configure_file("${CMAKE_SOURCE_DIR}/include/config.h.in"
 include_directories("${CMAKE_SOURCE_DIR}/include/")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+set(CMAKE_CONFIGURATION_TYPES "Debug;Release")
 
 IF(MSVC)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /Z7 /Od /W4")
@@ -75,5 +76,3 @@ IF(FMOD_FOUND)
   include_directories(SYSTEM ${FMOD_INCLUDE_DIRS})
   target_link_libraries(revengeMusic  ${FMOD_LIBRARIES})
 ENDIF(FMOD_FOUND)
-
-

--- a/build.cmd
+++ b/build.cmd
@@ -1,5 +1,6 @@
 mkdir build
 cd build
-cmake ../
-MSBuild revengeMusic.sln
+cmake ..
+msbuild revengeMusic.sln /p:Configuration=Debug
+msbuild revengeMusic.sln /p:Configuration=Release
 cd ..


### PR DESCRIPTION
Fixes #57 for Windows
I'm not sure this is the way it should be done, but it does work.