### PR TITLE
Handle bad audio files

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -176,7 +176,11 @@ int main( int argc, char *argv[]) {
         }
 
         std::cout << "Playing file: " << track_name << std::endl;
-        song.play(track_dir.c_str());
+        if(track_name == "") {
+            song.play();
+        } else {
+            song.play(track_dir.c_str());
+        }
 
         std::string msg;
         bool running = true;


### PR DESCRIPTION
I didn't realize FMOD had a fairly verbose error enums which removes the complexity code. If we are going to change the audio library it may not be worth it to handle all the types of errors.