### PR TITLE
Added UTF8 support for command line arguments in Windows

### DIFF
--- a/include/WindowsUtility.h
+++ b/include/WindowsUtility.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <Windows.h>
+
+//Takes a null terminated wchar_t string and returns a std::string with UTF8 encoding
+//Returns an empty string if the conversion fails
+std::string UTF16toUTF8string(wchar_t* UTF16str)
+{
+    //Check for invalid pointer
+    if(UTF16str == nullptr || UTF16str == NULL) { 
+        return std::string();
+    }
+
+    //Calculate how much space is needed for UTF8 string
+    int num_bytes = WideCharToMultiByte(CP_UTF8, 0, UTF16str, -1, NULL, 0, NULL, NULL );
+    
+    //Allocate memory for multibyte string
+    char* UTF8tempstr = new char[num_bytes];
+
+    int result = WideCharToMultiByte(
+        CP_UTF8, //Code Page
+        0, //Options flags
+        UTF16str, //Input string
+        -1, //Specifies to convert up until null character and appends null character
+        UTF8tempstr, //Output string
+        num_bytes, //Size in bytes of buffer for output string
+        NULL, //Must be NULL when converting to UTF8
+        NULL  //Must be NULL when converting to UTF8
+    );
+    
+    std::string UTF8str;
+    
+    if(result != 0) {
+        UTF8str = UTF8tempstr;
+    }
+        
+    delete[] UTF8tempstr;
+    
+    return UTF8str;
+}
+
+bool GetCommandLineToArgs(std::vector<wchar_t*> & output)
+{
+    int nArgs;
+    LPWSTR* szArglist = CommandLineToArgvW(GetCommandLineW(), &nArgs);
+    
+    if(szArglist == NULL) {
+      return false;
+    }
+    
+    for(int count = 0; count < nArgs; ++count) {
+        output.emplace_back(szArglist[count]);
+    }
+    
+    return true;
+}
+    

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -119,11 +119,11 @@ int main( int argc, char *argv[]) {
         std::string subdirectory;
 
         //Check command line arguments
-        for(int i = 1; i < argc; ++i) {
+        for(unsigned int i = 1; i < argv_str.size(); ++i) {
             if(argv_str[i] == "-subdir")
             {
                 ++i;
-                if(i < argc)
+                if(i < argv_str.size())
                 {
                   subdirectory = argv_str[i];
                   subdirectory += "/";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@
   #include <Knownfolders.h>
   #include <Shlobj.h>
   #include <cwchar>
+  #include "WindowsUtility.h"
   #undef GetMessage
   #undef SendMessage
 #else
@@ -37,9 +38,28 @@
 
 int main( int argc, char *argv[]) {
 
+    std::vector<std::string> argv_str;
+    
     #ifdef __unix
+      //Store arguments in vector of string
+      for(int i = 0; i < argc; ++i) {
+          argv_str.emplace_back(argv[i]);
+      }
+      
       errno = 0;
     #elif _WIN32
+      std::vector<wchar_t*> windows_args;
+      
+      if(!GetCommandLineToArgs(windows_args)) {
+          Logger::Error error(ErrorType::Fatal, "Could not interpret command line arguments!");
+          Logger::PrintError(error);
+          return -1;
+      }
+      
+      for(wchar_t* UTF16str : windows_args) {
+          argv_str.emplace_back(UTF16toUTF8string(UTF16str));
+      }
+      
       SetLastError(0);
     #endif
 
@@ -47,14 +67,7 @@ int main( int argc, char *argv[]) {
       SysError::SetLog(true);
     #endif
 
-    std::vector<std::string> argv_str;
-
-    if(argc > 1) {
-        //Store arguments in vector of string
-        for(int i = 0; i < argc; ++i) {
-            argv_str.emplace_back(argv[i]);
-        }
-
+    if(argv_str.size() > 1) {
         //Check for simple commands like --help or --version
         if(argv_str[1] == "-h" || argv_str[1] == "--help") {
             std::string msg =


### PR DESCRIPTION
Takes the command line arguments as wide strings with UTF16 encoding and converts them to narrow strings with UTF8 encoding.
I think I've made the right changes in main.cpp, but I think the problem is with calls to filesystem.
